### PR TITLE
ci: Adapt crowin action since code splitting

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -41,11 +41,11 @@ jobs:
         run: sudo apt-get install gettext
       - name: Build pot files
         run: |
-          cd artifact-builder
+          cd generator-angularjs
           yarn install && npm run pot
       - name: Concatenate pot files
         run: |
-          cd artifact-builder
+          cd generator-angularjs
           mkdir -p target/crowdin
           cat `find . -name '*.pot' -print` | msguniq -s > target/crowdin/widgets-lang-template.pot
       - name: Set Crowdin branch name


### PR DESCRIPTION
* Default widget are now in generator-angularjs submodule instead artifact builder