### PR TITLE
fix(properties): GeneratorProperties

### DIFF
--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/ArtifactBuilderFactory.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/ArtifactBuilderFactory.java
@@ -101,7 +101,9 @@ public class ArtifactBuilderFactory {
                 core.getWidgetAssetRepository(),
                 core.getPageAssetRepository(),
                 core.getFragmentRepository(),
-                uiDesignerProperties.getWorkspace().getWidgets().getDir());
+                uiDesignerProperties.getWorkspace().getWidgets().getDir(),
+                uiDesignerProperties.getWorkspaceUid().getPath(),
+                uiDesignerProperties.getWorkspaceUid().isLiveBuildEnabled());
         /**
          * END Specific generation
          */

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/config/UiDesignerPropertiesBuilder.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/config/UiDesignerPropertiesBuilder.java
@@ -62,7 +62,6 @@ public class UiDesignerPropertiesBuilder {
 
     public UiDesignerPropertiesBuilder workspaceUidPath(Path path) {
         this.workspaceUid.setPath(path);
-        this.workspaceUid.setExtractPath(this.workspaceUid.getPath().resolve("extract"));
         return this;
     }
 

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/config/WorkspaceUidProperties.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/config/WorkspaceUidProperties.java
@@ -39,8 +39,6 @@ public class WorkspaceUidProperties {
 
     private Path path = Path.of(System.getProperty("java.io.tmpdir")).resolve("workspace-uid");
 
-    private Path extractPath = getPath().resolve("extract");
-
     public Path getTmpFragmentsRepositoryPath() {
         return getPath().resolve(FRAGMENTS);
     }
@@ -55,6 +53,10 @@ public class WorkspaceUidProperties {
 
     public Path getExportBackendResourcesPath() {
         return getExtractPath().resolve(EXTRACT_BACKEND_RESOURCES).resolve("runtime");
+    }
+
+    public Path getExtractPath() {
+        return path.resolve("extract");
     }
 
     public Path getTemplateResourcesPath() {

--- a/artifact-builder/src/test/java/org/bonitasoft/web/designer/i18n/LanguagePackBuilderTest.java
+++ b/artifact-builder/src/test/java/org/bonitasoft/web/designer/i18n/LanguagePackBuilderTest.java
@@ -63,7 +63,7 @@ class LanguagePackBuilderTest {
     }
 
     private void newLanguagePackBuilder(boolean liveBuildEnabled) {
-        generatorProperties = new GeneratorProperties(this.tempDir.toString(), "i18n");
+        generatorProperties = new GeneratorProperties(this.tempDir);
         generatorProperties.setLiveBuildEnabled(liveBuildEnabled);
         builder = new LanguagePackBuilder(watcher, new LanguagePackFactory(
                 new JacksonJsonHandler(new ObjectMapper())), generatorProperties);

--- a/artifact-builder/src/test/java/org/bonitasoft/web/designer/workspace/WorkspaceInitializerTest.java
+++ b/artifact-builder/src/test/java/org/bonitasoft/web/designer/workspace/WorkspaceInitializerTest.java
@@ -34,7 +34,6 @@ import org.bonitasoft.web.designer.common.repository.PageRepository;
 import org.bonitasoft.web.designer.common.repository.WidgetRepository;
 import org.bonitasoft.web.designer.config.UiDesignerProperties;
 import org.bonitasoft.web.designer.config.WorkspaceProperties;
-import org.bonitasoft.web.designer.config.WorkspaceUidProperties;
 import org.bonitasoft.web.designer.controller.importer.dependencies.AssetDependencyImporter;
 import org.bonitasoft.web.designer.migration.LiveRepositoryUpdate;
 import org.bonitasoft.web.designer.model.JsonHandler;
@@ -54,10 +53,11 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class WorkspaceInitializerTest {
 
-    private Path extractPath;
-
     @TempDir
     public Path temporaryFolder;
+
+    @TempDir
+    public Path uidWorkspace;
 
     @Mock
     private LiveRepositoryUpdate<Page> pageRepositoryLiveUpdate;
@@ -72,14 +72,8 @@ class WorkspaceInitializerTest {
     @Mock
     private GeneratorStrategy generatorStrategy;
 
-    @Mock
-    private GeneratorProperties generatorProperties;
-
     @BeforeEach
     void setUp() throws IOException {
-
-        extractPath = Files.createDirectory(temporaryFolder.resolve("extract"));
-
         UiDesignerProperties uiDesignerProperties = newUiDesignerProperties();
 
         when(widgetRepository.resolvePath(anyString())).thenAnswer(invocation -> {
@@ -87,10 +81,9 @@ class WorkspaceInitializerTest {
             return uiDesignerProperties.getWorkspace().getWidgets().getDir().resolve(id);
         });
 
-        when(generatorStrategy.getGeneratorProperties()).thenReturn(generatorProperties);
+        when(generatorStrategy.getGeneratorProperties()).thenReturn(new GeneratorProperties(uidWorkspace));
         when(generatorStrategy.widgetFileBuilder()).thenReturn(mock(WidgetDirectiveBuilder.class));
         when(generatorStrategy.fragmentDirectiveBuilder()).thenReturn(mock(FragmentDirectiveBuilder.class));
-        when(generatorProperties.getExtractPath()).thenReturn(extractPath);
         PageRepository pageRepository = mock(PageRepository.class);
         AssetDependencyImporter<Widget> widgetAssetDependencyImporter = mock(AssetDependencyImporter.class);
 
@@ -120,10 +113,6 @@ class WorkspaceInitializerTest {
         workspaceProperties.getPages().setDir(Files.createDirectory(temporaryFolder.resolve("pages")));
         workspaceProperties.getWidgets().setDir(Files.createDirectory(temporaryFolder.resolve("widgets")));
         workspaceProperties.getFragments().setDir(Files.createDirectory(temporaryFolder.resolve("fragments")));
-
-        WorkspaceUidProperties workspaceUidProperties = uiDesignerProperties.getWorkspaceUid();
-        workspaceUidProperties.setExtractPath(extractPath);
-
         return uiDesignerProperties;
     }
 

--- a/artifact-builder/src/test/java/org/bonitasoft/web/designer/workspace/WorkspaceMigrationTest.java
+++ b/artifact-builder/src/test/java/org/bonitasoft/web/designer/workspace/WorkspaceMigrationTest.java
@@ -61,8 +61,6 @@ class WorkspaceMigrationTest {
         uiDesignerProperties.setVersion("1.13.0-SNAPSHOT");
         uiDesignerProperties.setEdition("Community");
         uiDesignerProperties.getWorkspaceUid().setPath(tempdir);
-        Path extract = Files.createDirectories(tempdir.resolve("extract"));
-        uiDesignerProperties.getWorkspaceUid().setExtractPath(extract);
 
         Path assetCss = Files.createDirectories(
                 uiDesignerProperties.getWorkspaceUid().getExtractPath().resolve("angularjs/templates/page/assets/css"));

--- a/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/AngularJsGeneratorStrategy.java
+++ b/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/AngularJsGeneratorStrategy.java
@@ -70,7 +70,9 @@ public class AngularJsGeneratorStrategy extends CommonGeneratorStrategy {
             AssetRepository<Widget> widgetAssetRepository,
             AssetRepository<Page> pageAssetRepository,
             FragmentRepository fragmentRepository,
-            Path widgetUserRepoPath) {
+            Path widgetUserRepoPath,
+            Path uidWorkspace,
+            boolean liveBuildEnabled) {
         this.widgetIdVisitor = widgetIdVisitor;
         this.directiveFileGenerator = directiveFileGenerator;
         this.widgetUserRepoPath = widgetUserRepoPath;
@@ -81,7 +83,8 @@ public class AngularJsGeneratorStrategy extends CommonGeneratorStrategy {
                 new PropertyValuesVisitor(fragmentRepository),
                 new VariableModelVisitor(fragmentRepository));
 
-        this.generatorProperties = new GeneratorProperties("workspace-uid", "i18n");
+        this.generatorProperties = new GeneratorProperties(uidWorkspace);
+        generatorProperties.setLiveBuildEnabled(liveBuildEnabled);
         this.htmlBuilderVisitor = new HtmlBuilderVisitor(fragmentRepository);
         var directivesCollector = new DirectivesCollector(jsonHandler,
                 generatorProperties.getTmpPagesRepositoryPath(),

--- a/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/GeneratorProperties.java
+++ b/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/GeneratorProperties.java
@@ -29,17 +29,15 @@ import lombok.Setter;
 public class GeneratorProperties implements IGeneratorProperties {
 
     public static final String EXTRACT_BACKEND_RESOURCES = "META-INF/resources";
+    public static final String I18N_RESOURCE = "i18n";
     private final Path path;
 
     @Getter
     @Setter
     private boolean isLiveBuildEnabled = true;
 
-    private final String i18NResourcesName;
-
-    public GeneratorProperties(String workspaceName, String i18nResourcesName) {
-        this.i18NResourcesName = i18nResourcesName;
-        this.path = Path.of(System.getProperty("java.io.tmpdir")).resolve(workspaceName);
+    public GeneratorProperties(Path uidWorkspace) {
+        this.path = uidWorkspace;
     }
 
     public static final String FRAGMENTS = "fragments";
@@ -57,7 +55,7 @@ public class GeneratorProperties implements IGeneratorProperties {
     }
 
     public Path getTmpI18nPath() throws IOException {
-        return createDirectories(getPath().resolve(this.i18NResourcesName));
+        return createDirectories(getPath().resolve(I18N_RESOURCE));
     }
 
     @Override


### PR DESCRIPTION
Use the same properties for the uid workspace between the WorksapceUidProperties and the GeneratorProperties

This was causing issues and the workspace uid path was not honored and tmp files were created in several places between a default /tmp/workspace-uid and the one defined in WorksapceUidProperties.

I also removed the configuration of the extractPath inside the uid workspace as it seems not relevant to specialize this path.

`liveBuildEnabled` was also not set on the GeneratorProperties.

I've made i18n resource path static also as I did not see the use case to have it as a property of GeneratorProperties.

I feel that WorksapceUidProperties should be shared between artifact builder module and angularjs generator to avoid having big constructors.