### PR TITLE
fix(encoding): add missing charset attribute

### DIFF
--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/controller/asset/AssetService.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/controller/asset/AssetService.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Predicate;
@@ -124,7 +125,7 @@ public class AssetService<T extends Assetable> {
     }
 
     public String getAssetContent(T component, Asset asset) throws IOException {
-        return new String(assetRepository.readAllBytes(component.getId(), asset));
+        return new String(assetRepository.readAllBytes(component.getId(), asset), StandardCharsets.UTF_8);
     }
 
     /**

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/StyleAddModalContainerPropertiesMigrationStep.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/StyleAddModalContainerPropertiesMigrationStep.java
@@ -19,6 +19,7 @@ package org.bonitasoft.web.designer.migration;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
@@ -60,7 +61,7 @@ public class StyleAddModalContainerPropertiesMigrationStep extends AbstractMigra
         try (var is = getClass()
                 .getResourceAsStream("/templates/migration/assets/css/styleAddModalContainerProperties.css");
                 var sis = new SequenceInputStream(
-                        new ByteArrayInputStream(styleCssContent.getBytes()),
+                        new ByteArrayInputStream(styleCssContent.getBytes(StandardCharsets.UTF_8)),
                         new ByteArrayInputStream(IOUtils.toByteArray(is)))) {
             return IOUtils.toByteArray(sis);
         }

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/StyleUpdateInputRequiredLabelMigrationStep.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/StyleUpdateInputRequiredLabelMigrationStep.java
@@ -17,6 +17,7 @@
 package org.bonitasoft.web.designer.migration;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -68,6 +69,6 @@ public class StyleUpdateInputRequiredLabelMigrationStep extends AbstractMigratio
 
         }
         m.appendTail(buffer);
-        return buffer.toString().getBytes();
+        return buffer.toString().getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/StyleUpdateInputTypeMigrationStep.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/StyleUpdateInputTypeMigrationStep.java
@@ -17,6 +17,7 @@
 package org.bonitasoft.web.designer.migration;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,7 +48,7 @@ public class StyleUpdateInputTypeMigrationStep extends AbstractMigrationStep<Pag
                 Matcher matcher = pattern.matcher(newContent);
                 if (matcher.find()) {
                     String updatedStyleContent = newContent.replaceAll(REGEX_SELECTOR, replacement);
-                    pageAssetService.save(page, asset, updatedStyleContent.getBytes());
+                    pageAssetService.save(page, asset, updatedStyleContent.getBytes(StandardCharsets.UTF_8));
                     logger.info("[MIGRATION] Update input style in asset [{}] for {} [{}]",
                             asset.getName(), page.getType(), page.getName());
                 }

--- a/common/src/main/java/org/bonitasoft/web/designer/common/repository/JsonFileBasedLoader.java
+++ b/common/src/main/java/org/bonitasoft/web/designer/common/repository/JsonFileBasedLoader.java
@@ -23,6 +23,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,11 +79,11 @@ public class JsonFileBasedLoader<T extends Identifiable> extends AbstractLoader<
                     continue;
                 }
 
-                var content = new String(readAllBytes(componentFile));
+                var content = new String(readAllBytes(componentFile), StandardCharsets.UTF_8);
                 String contentWithoutSpaces = removeSpaces(content);
                 T object;
                 try {
-                    object = jsonHandler.fromJson(content.getBytes(), type);
+                    object = jsonHandler.fromJson(content.getBytes(StandardCharsets.UTF_8), type);
                 } catch (IOException ex) {
                     throw new IOException("Json mapping error for " + componentFile, ex);
                 }
@@ -134,7 +135,7 @@ public class JsonFileBasedLoader<T extends Identifiable> extends AbstractLoader<
                 //We consider only another objects
                 if (objectPath == null || !objectPath.equals(componentFile)) {
                     var content = readAllBytes(componentFile);
-                    if (indexOf(content, objectId.getBytes()) >= 0) {
+                    if (indexOf(content, objectId.getBytes(StandardCharsets.UTF_8)) >= 0) {
                         return true;
                     }
                 }

--- a/common/src/main/java/org/bonitasoft/web/designer/common/repository/JsonFileBasedPersister.java
+++ b/common/src/main/java/org/bonitasoft/web/designer/common/repository/JsonFileBasedPersister.java
@@ -21,6 +21,7 @@ import static java.nio.file.Files.readAllBytes;
 import static java.nio.file.Files.write;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -132,7 +133,7 @@ public class JsonFileBasedPersister<T extends Identifiable> {
             } catch (Exception e) {
                 if (indexFileContent.length > 0) { //file is not empty and cannot be parsed
                     logger.error("Failed to parse '{}' file with content:\n{}",
-                            indexPath, new String(indexFileContent), e);
+                            indexPath, new String(indexFileContent, StandardCharsets.UTF_8), e);
                 }
                 //else file is empty, ignore exception
             }

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/MinifierTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/MinifierTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.bonitasoft.web.angularjs.export.Minifier;
 import org.bonitasoft.web.designer.common.generator.rendering.GenerationException;
@@ -44,7 +45,7 @@ class MinifierTest {
 
         byte[] min = Minifier.minify(content.getBytes());
 
-        assertThat(new String(min, "UTF-8")).isEqualTo(expected);
+        assertThat(new String(min, StandardCharsets.UTF_8)).isEqualTo(expected);
     }
 
     @Test

--- a/model/src/main/java/org/bonitasoft/web/designer/model/JacksonJsonHandler.java
+++ b/model/src/main/java/org/bonitasoft/web/designer/model/JacksonJsonHandler.java
@@ -113,7 +113,8 @@ public class JacksonJsonHandler implements JsonHandler {
         objectMapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
         try {
             return objectMapper
-                    .writerWithDefaultPrettyPrinter().writeValueAsString(object);
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(object);
         } finally {
             objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         }

--- a/model/src/main/java/org/bonitasoft/web/designer/model/JsonHandlerFactory.java
+++ b/model/src/main/java/org/bonitasoft/web/designer/model/JsonHandlerFactory.java
@@ -51,7 +51,7 @@ public class JsonHandlerFactory {
 
         //By default all properties without explicit view definition are included in serialization.
         //To use JsonView we have to change this parameter
-        objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
+        objectMapper.disable(MapperFeature.DEFAULT_VIEW_INCLUSION);
 
         //We don't have to serialize null values
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/model/src/main/java/org/bonitasoft/web/designer/model/widget/Widget.java
+++ b/model/src/main/java/org/bonitasoft/web/designer/model/widget/Widget.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import static java.nio.file.Files.readAllBytes;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -357,7 +358,7 @@ public class Widget extends DesignerArtifact implements Identifiable, Assetable 
             if (!Files.exists(controllerFile)) {
                 throw new NotFoundException(format("Controller not found for [%s]", controllerFile.getFileName()));
             }
-            this.setController(new String(readAllBytes(controllerFile)));
+            this.setController(new String(readAllBytes(controllerFile), StandardCharsets.UTF_8));
         }
     }
 
@@ -373,7 +374,7 @@ public class Widget extends DesignerArtifact implements Identifiable, Assetable 
             if (!Files.exists(templateFile)) {
                 throw new NotFoundException(format("Template not found for [%s]", templateFile.getFileName()));
             }
-            this.setTemplate(new String(readAllBytes(templateFile)));
+            this.setTemplate(new String(readAllBytes(templateFile), StandardCharsets.UTF_8));
         }
     }
 


### PR DESCRIPTION
When converting `String` into `byte[]` and the other way around, UTF-8 charset must be forced to have a homogenous behavior between unix and windows system.

Closes UID-722