### PR TITLE
feat(HTTP error dialog): add migration step for translations

### DIFF
--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
@@ -159,7 +159,8 @@ public class UiDesignerCoreFactory {
                 new Migration<>("2.3", new SetInterpretHtmlTrueMigrationStep<>(componentVisitor)),
                 new Migration<>("2.4", new AccessibilityCheckListAndRadioButtonsMigrationStep(componentVisitor)),
                 new Migration<>("2.5", new StyleUpdateInputTypeMigrationStep(pageAssetService)),
-                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService), new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService)));
+                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService),
+                        new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService)));
 
         List<Migration<Widget>> widgetMigrationStepsList = List.<Migration<Widget>> of(
                 new Migration<>("1.0.2", new AssetIdMigrationStep<>()),

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
@@ -159,7 +159,8 @@ public class UiDesignerCoreFactory {
                 new Migration<>("2.3", new SetInterpretHtmlTrueMigrationStep<>(componentVisitor)),
                 new Migration<>("2.4", new AccessibilityCheckListAndRadioButtonsMigrationStep(componentVisitor)),
                 new Migration<>("2.5", new StyleUpdateInputTypeMigrationStep(pageAssetService)),
-                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService)));
+                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService)),
+                new Migration<>("2.6", new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService)));
 
         List<Migration<Widget>> widgetMigrationStepsList = List.<Migration<Widget>> of(
                 new Migration<>("1.0.2", new AssetIdMigrationStep<>()),

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
@@ -159,8 +159,7 @@ public class UiDesignerCoreFactory {
                 new Migration<>("2.3", new SetInterpretHtmlTrueMigrationStep<>(componentVisitor)),
                 new Migration<>("2.4", new AccessibilityCheckListAndRadioButtonsMigrationStep(componentVisitor)),
                 new Migration<>("2.5", new StyleUpdateInputTypeMigrationStep(pageAssetService)),
-                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService)),
-                new Migration<>("2.6", new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService)));
+                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService), new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService)));
 
         List<Migration<Widget>> widgetMigrationStepsList = List.<Migration<Widget>> of(
                 new Migration<>("1.0.2", new AssetIdMigrationStep<>()),

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/UiDesignerCoreFactory.java
@@ -159,7 +159,7 @@ public class UiDesignerCoreFactory {
                 new Migration<>("2.3", new SetInterpretHtmlTrueMigrationStep<>(componentVisitor)),
                 new Migration<>("2.4", new AccessibilityCheckListAndRadioButtonsMigrationStep(componentVisitor)),
                 new Migration<>("2.5", new StyleUpdateInputTypeMigrationStep(pageAssetService)),
-                new Migration<>("2.6", new StyleAddModalContainerPropertiesMigrationStep(pageAssetService),
+                new Migration<>("2.6", new StyleAddErrorDialogPropertiesMigrationStep(pageAssetService),
                         new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService)));
 
         List<Migration<Widget>> widgetMigrationStepsList = List.<Migration<Widget>> of(

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/controller/asset/AssetService.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/controller/asset/AssetService.java
@@ -125,7 +125,11 @@ public class AssetService<T extends Assetable> {
     }
 
     public String getAssetContent(T component, Asset asset) throws IOException {
-        return new String(assetRepository.readAllBytes(component.getId(), asset), StandardCharsets.UTF_8);
+        return new String(getAssetBinaryContent(component, asset), StandardCharsets.UTF_8);
+    }
+
+    public byte[] getAssetBinaryContent(T component, Asset asset) throws IOException {
+        return assetRepository.readAllBytes(component.getId(), asset);
     }
 
     /**

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStep.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStep.java
@@ -1,0 +1,90 @@
+/** 
+ * Copyright (C) 2023 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.bonitasoft.web.designer.migration;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
+import org.apache.commons.io.IOUtils;
+import org.bonitasoft.web.designer.controller.asset.AssetService;
+import org.bonitasoft.web.designer.model.JacksonJsonHandler;
+import org.bonitasoft.web.designer.model.JsonHandler;
+import org.bonitasoft.web.designer.model.migrationReport.MigrationStepReport;
+import org.bonitasoft.web.designer.model.page.Page;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class LocalizationAddErrorDialogTranslationsMigrationStep extends AbstractMigrationStep<Page> {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(LocalizationAddErrorDialogTranslationsMigrationStep.class);
+
+    private AssetService<Page> assetService;
+
+    private JsonHandler jsonHandler;
+
+    public LocalizationAddErrorDialogTranslationsMigrationStep(AssetService<Page> assetService) {
+        this.assetService = assetService;
+        this.jsonHandler = new JacksonJsonHandler(new ObjectMapper());
+    }
+
+    @Override
+    public Optional<MigrationStepReport> migrate(Page artifact) throws IOException {
+        for (var asset : artifact.getAssets()) {
+            if (asset.getName().equals("localization.json")) {
+                var pageLocalizationContent = assetService.getAssetBinaryContent(artifact, asset);
+                assetService.save(artifact, asset, getMigratedAssetContent(pageLocalizationContent));
+                logger.info(
+                        "[MIGRATION] Adding error dialog translations in asset [{}] to {} [{}] (introduced in 1.17.5)",
+                        asset.getName(), artifact.getType(), artifact.getName());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return "Error during adding error dialog translations in asset, Missing templates/page/assets/json/localization.json from classpath";
+    }
+
+    private byte[] getMigratedAssetContent(byte[] pageLocalizationContent) throws IOException {
+        LinkedHashMap<String, Object> existingTranslations = jsonHandler.fromJsonToComplexMap(pageLocalizationContent);
+        LinkedHashMap<String, Object> newLocalizationContent = new LinkedHashMap<>();
+
+        try (var is = getClass()
+                .getResourceAsStream("/templates/migration/assets/json/localizationAddErrorDialogTranslations.json")) {
+            LinkedHashMap<String, Object> translationsToAdd = jsonHandler.fromJsonToComplexMap(IOUtils.toByteArray(is));
+            for (String language : existingTranslations.keySet()) {
+                LinkedHashMap<String, String> existingLanguageTranslations = (LinkedHashMap<String, String>) existingTranslations
+                        .get(language);
+                LinkedHashMap<String, String> languageTranslationsToAdd = (LinkedHashMap<String, String>) translationsToAdd
+                        .get(language);
+                LinkedHashMap<String, String> mergedLanguageTranslations = new LinkedHashMap<>();
+                mergedLanguageTranslations.putAll(existingLanguageTranslations);
+                if (languageTranslationsToAdd != null) {
+                    mergedLanguageTranslations.putAll(languageTranslationsToAdd);
+                }
+                newLocalizationContent.put(language, mergedLanguageTranslations);
+            }
+            String test = IOUtils.toString(jsonHandler.toPrettyJsonFromComplexMap(newLocalizationContent), "UTF-8");
+            return jsonHandler.toPrettyJsonFromComplexMap(newLocalizationContent);
+        }
+    }
+}

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStep.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStep.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.bonitasoft.web.designer.controller.asset.AssetService;
 import org.bonitasoft.web.designer.model.JacksonJsonHandler;
@@ -31,10 +32,8 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@Slf4j
 public class LocalizationAddErrorDialogTranslationsMigrationStep extends AbstractMigrationStep<Page> {
-
-    private static final Logger logger = LoggerFactory
-            .getLogger(LocalizationAddErrorDialogTranslationsMigrationStep.class);
 
     private AssetService<Page> assetService;
 
@@ -51,8 +50,7 @@ public class LocalizationAddErrorDialogTranslationsMigrationStep extends Abstrac
             if (asset.getName().equals("localization.json")) {
                 var pageLocalizationContent = assetService.getAssetBinaryContent(artifact, asset);
                 assetService.save(artifact, asset, getMigratedAssetContent(pageLocalizationContent));
-                logger.info(
-                        "[MIGRATION] Adding error dialog translations in asset [{}] to {} [{}] (introduced in 1.17.5)",
+                log.info("[MIGRATION] Adding error dialog translations in asset [{}] to {} [{}] (introduced in 1.17.5)",
                         asset.getName(), artifact.getType(), artifact.getName());
             }
         }
@@ -83,7 +81,6 @@ public class LocalizationAddErrorDialogTranslationsMigrationStep extends Abstrac
                 }
                 newLocalizationContent.put(language, mergedLanguageTranslations);
             }
-            String test = IOUtils.toString(jsonHandler.toPrettyJsonFromComplexMap(newLocalizationContent), "UTF-8");
             return jsonHandler.toPrettyJsonFromComplexMap(newLocalizationContent);
         }
     }

--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStep.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStep.java
@@ -20,17 +20,16 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.bonitasoft.web.designer.controller.asset.AssetService;
 import org.bonitasoft.web.designer.model.JacksonJsonHandler;
 import org.bonitasoft.web.designer.model.JsonHandler;
 import org.bonitasoft.web.designer.model.migrationReport.MigrationStepReport;
 import org.bonitasoft.web.designer.model.page.Page;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class LocalizationAddErrorDialogTranslationsMigrationStep extends AbstractMigrationStep<Page> {

--- a/artifact-builder/src/test/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStepTest.java
+++ b/artifact-builder/src/test/java/org/bonitasoft/web/designer/migration/LocalizationAddErrorDialogTranslationsMigrationStepTest.java
@@ -1,0 +1,73 @@
+/** 
+ * Copyright (C) 2023 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.bonitasoft.web.designer.migration;
+
+import static org.bonitasoft.web.designer.builder.AssetBuilder.anAsset;
+import static org.bonitasoft.web.designer.builder.PageBuilder.aPage;
+import static org.bonitasoft.web.designer.model.asset.AssetType.JSON;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.bonitasoft.web.designer.controller.asset.AssetService;
+import org.bonitasoft.web.designer.model.asset.Asset;
+import org.bonitasoft.web.designer.model.page.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocalizationAddErrorDialogTranslationsMigrationStepTest {
+
+    @Mock
+    private AssetService<Page> pageAssetService;
+
+    @InjectMocks
+    private LocalizationAddErrorDialogTranslationsMigrationStep step;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        step = new LocalizationAddErrorDialogTranslationsMigrationStep(pageAssetService);
+    }
+
+    private Asset expectedAsset(String name) {
+        return anAsset().withType(JSON).withName(name).build();
+    }
+
+    @Test
+    void should_migrate_localization_asset_to_add_new_error_dialog_translations() throws Exception {
+        Asset json = anAsset().withType(JSON).withName("localization.json").build();
+        InputStream initialContent = getClass()
+                .getResourceAsStream("initialLocalization.json");
+        Page page = aPage()
+                .withModelVersion("2.5").withAsset(json).build();
+
+        when(pageAssetService.getAssetBinaryContent(page, json)).thenReturn(IOUtils.toByteArray(initialContent));
+
+        step.migrate(page);
+
+        InputStream expectedContent = getClass()
+                .getResourceAsStream("expectedLocalization.json");
+        verify(pageAssetService).save(page, expectedAsset("localization.json"), IOUtils.toByteArray(expectedContent));
+    }
+
+}

--- a/artifact-builder/src/test/resources/org/bonitasoft/web/designer/migration/expectedLocalization.json
+++ b/artifact-builder/src/test/resources/org/bonitasoft/web/designer/migration/expectedLocalization.json
@@ -1,0 +1,42 @@
+{
+  "fr-FR": {
+    "Title": "Titre",
+    "OK": "OK",
+    "$locale": {
+      "DATETIME_FORMATS": {
+        "AMPMS": [
+          "AM",
+          "PM"
+        ]
+      }
+    },
+    "An error occurred with the requested operation": "Une erreur s'est produite lors de l'opération demandée",
+    "Your session is no longer active.": "Votre session n'est plus active.",
+    "Click on OK to be redirected and log back in.": "Cliquez sur OK pour être redirigé et vous reconnecter.",
+    "Click on Cancel to remain on this page and try to execute the operation again once you logged back in (e.g. in another tab).": "Cliquez sur Annuler pour rester sur cette page et essayer d'exécuter à nouveau l'opération après vous être reconnecté (e.g. dans un autre onglet).",
+    "Server is under maintenance.": "Une maintenance est en cours sur le serveur.",
+    "Click on OK to be redirected to the maintenance page.": "Cliquez sur OK pour être redirigé vers la page de maintenance.",
+    "Click on Cancel to remain on this page and wait for the maintenance to end.": "Cliquez sur Annuler pour rester sur cette page et attendre la fin des opérations de maintenance.",
+    "Cancel": "Annuler"
+  },
+  "es-ES": {
+    "Title": "Título",
+    "OK": "Aceptar",
+    "$locale": {
+      "DATETIME_FORMATS": {
+        "AMPMS": [
+          "a. m.",
+          "p. m."
+        ]
+      }
+    },
+    "An error occurred with the requested operation": "Ha ocurrido un error con la operación solicitada",
+    "Your session is no longer active.": "Su sesión ya no es válida o ha expirado.",
+    "Click on OK to be redirected and log back in.": "Haz click en Aceptar para volver a iniciar sesión.",
+    "Click on Cancel to remain on this page and try to execute the operation again once you logged back in (e.g. in another tab).": "Haz click en Cancelar para permanecer en esta página e intentar de nuevo la operación cuando su sesión sera de nuevo iniciada (p.ej. en otra pestaña).",
+    "Server is under maintenance.": "El servidor está en mantenimiento.",
+    "Click on OK to be redirected to the maintenance page.": "Haz click en Aceptar para ser redirigido.",
+    "Click on Cancel to remain on this page and wait for the maintenance to end.": "Haz click en Cancelar para permanecer en esta página y esperar a que finalice el mantenimiento.",
+    "Cancel": "Cancelar"
+  }
+}

--- a/artifact-builder/src/test/resources/org/bonitasoft/web/designer/migration/initialLocalization.json
+++ b/artifact-builder/src/test/resources/org/bonitasoft/web/designer/migration/initialLocalization.json
@@ -1,0 +1,26 @@
+{
+  "fr-FR": {
+    "Title": "Titre",
+    "OK": "Accepter",
+    "$locale": {
+      "DATETIME_FORMATS": {
+        "AMPMS": [
+          "AM",
+          "PM"
+        ]
+      }
+    }
+  },
+  "es-ES": {
+    "Title": "Título",
+    "OK": "OK",
+    "$locale": {
+      "DATETIME_FORMATS": {
+        "AMPMS": [
+          "a. m.",
+          "p. m."
+        ]
+      }
+    }
+  }
+}

--- a/generator-angularjs/src/main/resources/templates/migration/assets/json/localizationAddErrorDialogTranslations.json
+++ b/generator-angularjs/src/main/resources/templates/migration/assets/json/localizationAddErrorDialogTranslations.json
@@ -1,0 +1,46 @@
+{
+  "fr-FR": {
+    "An error occurred with the requested operation": "Une erreur s'est produite lors de l'opération demandée",
+    "Your session is no longer active.": "Votre session n'est plus active.",
+    "Click on OK to be redirected and log back in.": "Cliquez sur OK pour être redirigé et vous reconnecter.",
+    "Click on Cancel to remain on this page and try to execute the operation again once you logged back in (e.g. in another tab).": "Cliquez sur Annuler pour rester sur cette page et essayer d'exécuter à nouveau l'opération après vous être reconnecté (e.g. dans un autre onglet).",
+    "Server is under maintenance.": "Une maintenance est en cours sur le serveur.",
+    "Click on OK to be redirected to the maintenance page.": "Cliquez sur OK pour être redirigé vers la page de maintenance.",
+    "Click on Cancel to remain on this page and wait for the maintenance to end.": "Cliquez sur Annuler pour rester sur cette page et attendre la fin des opérations de maintenance.",
+    "OK": "OK",
+    "Cancel": "Annuler"
+  },
+  "es-ES": {
+    "An error occurred with the requested operation": "Ha ocurrido un error con la operación solicitada",
+    "Your session is no longer active.": "Su sesión ya no es válida o ha expirado.",
+    "Click on OK to be redirected and log back in.": "Haz click en Aceptar para volver a iniciar sesión.",
+    "Click on Cancel to remain on this page and try to execute the operation again once you logged back in (e.g. in another tab).": "Haz click en Cancelar para permanecer en esta página e intentar de nuevo la operación cuando su sesión sera de nuevo iniciada (p.ej. en otra pestaña).",
+    "Server is under maintenance.": "El servidor está en mantenimiento.",
+    "Click on OK to be redirected to the maintenance page.": "Haz click en Aceptar para ser redirigido.",
+    "Click on Cancel to remain on this page and wait for the maintenance to end.": "Haz click en Cancelar para permanecer en esta página y esperar a que finalice el mantenimiento.",
+    "OK": "Aceptar",
+    "Cancel": "Cancelar"
+  },
+  "ja-JP": {
+    "An error occurred with the requested operation": "要求された操作でエラーが発生しました。",
+    "Your session is no longer active.": "セッションは既にアクティブではありません。",
+    "Click on OK to be redirected and log back in.": "OKをクリックするとリダイレクトされ、再度ログインします。",
+    "Click on Cancel to remain on this page and try to execute the operation again once you logged back in (e.g. in another tab).": "キャンセルをクリックしてこのページのまま、再度ログインしてから (別のタブなどで) 操作を再度実行してください。",
+    "Server is under maintenance.": "サーバーはメンテナンス中です。",
+    "Click on OK to be redirected to the maintenance page.": "OKをクリックすると、メンテナンス ページにリダイレクトされます。",
+    "Click on Cancel to remain on this page and wait for the maintenance to end.": "このページのまま、メンテナンスが終了するまで待つには［キャンセル]をクリックしてください。",
+    "OK": "OK",
+    "Cancel": "キャンセル"
+  },
+  "pt-BR": {
+    "An error occurred with the requested operation": "Ocorreu um erro com a operação solicitada",
+    "Your session is no longer active.": "Sua sessão não está mais ativa.",
+    "Click on OK to be redirected and log back in.": "Clique em OK para ser redirecionado e faça login novamente.",
+    "Click on Cancel to remain on this page and try to execute the operation again once you logged back in (e.g. in another tab).": "Clique em Cancelar para permanecer nesta página e tente executar a operação novamente depois de fazer login novamente (por exemplo, em outra guia).",
+    "Server is under maintenance.": "O servidor está em manutenção.",
+    "Click on OK to be redirected to the maintenance page.": "Clique em OK para ser redirecionado para a página de manutenção.",
+    "Click on Cancel to remain on this page and wait for the maintenance to end.": "Clique em Cancelar para permanecer nesta página e aguardar o término da manutenção.",
+    "OK": "OK",
+    "Cancel": "Cancelar"
+  }
+}

--- a/model/src/main/java/org/bonitasoft/web/designer/model/JacksonJsonHandler.java
+++ b/model/src/main/java/org/bonitasoft/web/designer/model/JacksonJsonHandler.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.bonitasoft.web.designer.model.exception.MalformedJsonException;
@@ -70,6 +71,13 @@ public class JacksonJsonHandler implements JsonHandler {
     }
 
     @Override
+    public LinkedHashMap<String, Object> fromJsonToComplexMap(byte[] bytes) throws IOException {
+        var factory = TypeFactory.defaultInstance();
+        var mapType = factory.constructMapType(LinkedHashMap.class, String.class, Object.class);
+        return objectMapper.readValue(bytes, mapType);
+    }
+
+    @Override
     public byte[] toJson(Object object) throws IOException {
         // Use UTF8 to accept any character and have platform-independent files.
         return objectMapper.writeValueAsString(object).getBytes(StandardCharsets.UTF_8);
@@ -96,6 +104,15 @@ public class JacksonJsonHandler implements JsonHandler {
     public byte[] toJson(Map<String, String> map) throws IOException {
         // Use UTF8 to accept any character and have platform-independent files.
         return objectMapper.writeValueAsString(map).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte[] toPrettyJsonFromComplexMap(LinkedHashMap<String, Object> map) throws IOException {
+        // Use UTF8 to accept any character and have platform-independent files.
+        return objectMapper.writer().with(new LocalizationPrettyPrinter(": ")
+                .withArrayIndenter(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE))
+                .writeValueAsString(map)
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/model/src/main/java/org/bonitasoft/web/designer/model/JsonHandler.java
+++ b/model/src/main/java/org/bonitasoft/web/designer/model/JsonHandler.java
@@ -18,6 +18,7 @@ package org.bonitasoft.web.designer.model;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -33,6 +34,8 @@ public interface JsonHandler {
 
     Map<String, String> fromJsonToMap(byte[] bytes) throws IOException;
 
+    LinkedHashMap<String, Object> fromJsonToComplexMap(byte[] bytes) throws IOException;
+
     byte[] toJson(Object object) throws IOException;
 
     byte[] toJson(Object object, Class<?> serializationView) throws IOException;
@@ -42,6 +45,8 @@ public interface JsonHandler {
     String toJsonString(Object object, Class<?> serializationView) throws IOException;
 
     byte[] toJson(Map<String, String> map) throws IOException;
+
+    byte[] toPrettyJsonFromComplexMap(LinkedHashMap<String, Object> map) throws IOException;
 
     byte[] toPrettyJson(Object object, Class<?> serializationView) throws IOException;
 

--- a/model/src/main/java/org/bonitasoft/web/designer/model/LocalizationPrettyPrinter.java
+++ b/model/src/main/java/org/bonitasoft/web/designer/model/LocalizationPrettyPrinter.java
@@ -1,0 +1,36 @@
+/** 
+ * Copyright (C) 2023 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.bonitasoft.web.designer.model;
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+public class LocalizationPrettyPrinter extends DefaultPrettyPrinter {
+
+    public LocalizationPrettyPrinter(String objectFieldValueSeparatorWithSpaces) {
+        super();
+        this._objectFieldValueSeparatorWithSpaces = objectFieldValueSeparatorWithSpaces;
+    }
+
+    private LocalizationPrettyPrinter(LocalizationPrettyPrinter localizationPrettyPrinter) {
+        super(localizationPrettyPrinter);
+    }
+
+    @Override
+    public DefaultPrettyPrinter createInstance() {
+        return new LocalizationPrettyPrinter(this);
+    }
+}


### PR DESCRIPTION
* add migration step to add new translations at the end of existing ones (use LinkedMap to preserve order when serializing, and pretty print with same format as existing localization.json)

Covers DEV-545
Relates to DEV-485
Relates to RUNTIME-531