### PR TITLE
fix(cache): Add model version query param to vendor and runtime js

### DIFF
--- a/artifact-builder/src/main/java/org/bonitasoft/web/designer/ArtifactBuilderFactory.java
+++ b/artifact-builder/src/main/java/org/bonitasoft/web/designer/ArtifactBuilderFactory.java
@@ -106,7 +106,8 @@ public class ArtifactBuilderFactory {
                 core.getPageAssetRepository(),
                 core.getFragmentRepository(),
                 uiDesignerProperties.getWorkspace().getWidgets().getDir(),
-                generatorProperties);
+                generatorProperties,
+                uiDesignerProperties.getModelVersion());
 
         /**
          * END Specific generation

--- a/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/AngularJsGeneratorStrategy.java
+++ b/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/AngularJsGeneratorStrategy.java
@@ -71,7 +71,8 @@ public class AngularJsGeneratorStrategy extends CommonGeneratorStrategy {
             AssetRepository<Page> pageAssetRepository,
             FragmentRepository fragmentRepository,
             Path widgetUserRepoPath,
-            GeneratorProperties generatorProperties) {
+            GeneratorProperties generatorProperties,
+            String modelVersion) {
         this.generatorProperties = generatorProperties;
         this.widgetIdVisitor = widgetIdVisitor;
         this.directiveFileGenerator = directiveFileGenerator;
@@ -99,7 +100,8 @@ public class AngularJsGeneratorStrategy extends CommonGeneratorStrategy {
                 assetVisitor,
                 widgetAssetRepository,
                 pageAssetRepository,
-                pageFactories);
+                pageFactories,
+                modelVersion);
         this.fragmentDirectiveBuilder = new FragmentDirectiveBuilder(watcher, jsonHandler,
                 this.getHtmlBuilderVisitor(),
                 this.generatorProperties.isLiveBuildEnabled());

--- a/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/rendering/DefaultHtmlGenerator.java
+++ b/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/rendering/DefaultHtmlGenerator.java
@@ -58,13 +58,16 @@ public class DefaultHtmlGenerator implements HtmlGenerator {
 
     private final List<PageFactory> pageFactories;
 
+    private String modelVersion;
+
     public DefaultHtmlGenerator(HtmlBuilderVisitor htmlBuilderVisitor,
             DirectivesCollector directivesCollector,
             RequiredModulesVisitor requiredModulesVisitor,
             AssetVisitor assetVisitor,
             AssetRepository<Widget> widgetAssetRepository,
             AssetRepository<Page> pageAssetRepository,
-            List<PageFactory> pageFactories) {
+            List<PageFactory> pageFactories,
+            String modelVersion) {
         this.htmlBuilderVisitor = htmlBuilderVisitor;
         this.directivesCollector = directivesCollector;
         this.requiredModulesVisitor = requiredModulesVisitor;
@@ -72,6 +75,7 @@ public class DefaultHtmlGenerator implements HtmlGenerator {
         this.widgetAssetRepository = widgetAssetRepository;
         this.pageAssetRepository = pageAssetRepository;
         this.pageFactories = pageFactories;
+        this.modelVersion = modelVersion;
     }
 
     public <P extends Previewable & Identifiable> String generateHtml(P previewable)
@@ -99,6 +103,7 @@ public class DefaultHtmlGenerator implements HtmlGenerator {
         var sortedAssets = getSortedAssets(previewable);
         var template = new TemplateEngine("page.hbs.html")
                 .with("resourceContext", resourceContext == null ? "" : resourceContext)
+                .with("uidModelVersion", modelVersion)
                 .with("directives",
                         this.directivesCollector.buildUniqueDirectivesFiles(previewable, previewable.getId()))
                 .with("rowsHtml", htmlBuilderVisitor.build(previewable.getRows()))

--- a/generator-angularjs/src/main/resources/templates/page.hbs.html
+++ b/generator-angularjs/src/main/resources/templates/page.hbs.html
@@ -19,8 +19,8 @@
             <link rel="stylesheet" href="{{ this }}">
     {{/each}}
 
-    <script src="{{resourceContext}}js/vendor.min.js"></script>
-    <script src="{{resourceContext}}js/runtime.min.js"></script>
+    <script src="{{resourceContext}}js/vendor.min.js?modelVersion={{uidModelVersion}}"></script>
+    <script src="{{resourceContext}}js/runtime.min.js?modelVersion={{uidModelVersion}}"></script>
     <!-- assets attached to the page -->
     {{#each jsAsset}}
             <script src="{{ this }}"></script>

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/DefaultHtmlGeneratorTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/DefaultHtmlGeneratorTest.java
@@ -92,6 +92,7 @@ class DefaultHtmlGeneratorTest {
 
     private HtmlBuilderVisitor htmlBuilderVisitor;
     private DefaultHtmlGenerator generator;
+    private String modelVersion = "2.5";
 
     @BeforeEach
     void setUp() throws Exception {
@@ -103,9 +104,24 @@ class DefaultHtmlGeneratorTest {
                 assetVisitor,
                 widgetAssetRepository,
                 pageAssetRepository,
-                List.of(pageFactory));
+                List.of(pageFactory),
+                modelVersion);
 
         assetSHA1 = DigestUtils.sha1Hex(assetsContent);
+    }
+
+    @Test
+    void should_generate_an_html_with_the_model_version_in_the_js_resources_URLs() throws Exception {
+        Page page = aPage().withId("page-id").build();
+
+        // when we generate the html
+        String generatedHtml = generator.build(page, "mycontext/");
+
+        // then we should have the directive scripts included
+        assertThat(generatedHtml)
+                .contains("<script src=\"mycontext/js/vendor.min.js?modelVersion=" + modelVersion + "\"></script>")
+                .contains("<script src=\"mycontext/js/runtime.min.js?modelVersion=" + modelVersion + "\"></script>")
+                .contains("pb-model='page-id'"); // and an empty object as constant
     }
 
     @Test

--- a/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/fragmentWithNoContext.html
+++ b/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/fragmentWithNoContext.html
@@ -8,8 +8,8 @@
     <link rel='stylesheet' href='mycontext/css/ngDialog.min.css'>
     <link rel='stylesheet' href='mycontext/css/ngDialog-theme-default.min.css'>
     <link rel="stylesheet" href="../theme/theme.css">
-    <script src="mycontext/js/vendor.min.js"></script>
-    <script src="mycontext/js/runtime.min.js"></script>
+    <script src="mycontext/js/vendor.min.js?modelVersion=2.5"></script>
+    <script src="mycontext/js/runtime.min.js?modelVersion=2.5"></script>
     <!-- assets attached to the page -->
     <!-- widgets directives minified --></head>
 <body ng-app="bonitasoft.ui" pb-model='page-id'>

--- a/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/page.html
+++ b/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/page.html
@@ -10,8 +10,8 @@
     <link rel='stylesheet' href='mycontext/css/ngDialog-theme-default.min.css'>
     <link rel="stylesheet" href="../theme/theme.css">
 
-    <script src="mycontext/js/vendor.min.js"></script>
-    <script src="mycontext/js/runtime.min.js"></script>
+    <script src="mycontext/js/vendor.min.js?modelVersion=2.5"></script>
+    <script src="mycontext/js/runtime.min.js?modelVersion=2.5"></script>
 
     <!-- assets attached to the page -->
     <script src="assets/js/bonita.vendors.js?hash=da39a3ee5e6b4b0d3255bfef95601890afd80709"></script>

--- a/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/pageCustomDisplayName.html
+++ b/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/pageCustomDisplayName.html
@@ -10,8 +10,8 @@
     <link rel='stylesheet' href='mycontext/css/ngDialog-theme-default.min.css'>
     <link rel="stylesheet" href="../theme/theme.css">
 
-    <script src="mycontext/js/vendor.min.js"></script>
-    <script src="mycontext/js/runtime.min.js"></script>
+    <script src="mycontext/js/vendor.min.js?modelVersion=2.5"></script>
+    <script src="mycontext/js/runtime.min.js?modelVersion=2.5"></script>
     <!-- assets attached to the page -->
     <!-- widgets directives minified -->
 </head>

--- a/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/pageWithNoContext.html
+++ b/generator-angularjs/src/test/resources/org/bonitasoft/web/angularjs/rendering/pageWithNoContext.html
@@ -8,8 +8,8 @@
     <link rel='stylesheet' href='css/ngDialog.min.css'>
     <link rel='stylesheet' href='css/ngDialog-theme-default.min.css'>
     <link rel="stylesheet" href="../theme/theme.css">
-    <script src="js/vendor.min.js"></script>
-    <script src="js/runtime.min.js"></script>
+    <script src="js/vendor.min.js?modelVersion=2.5"></script>
+    <script src="js/runtime.min.js?modelVersion=2.5"></script>
     <!-- assets attached to the page --><!-- widgets directives minified -->
 </head>
 <body ng-app="bonitasoft.ui" pb-model='page-id'>


### PR DESCRIPTION
Covers [UID-723](https://bonitasoft.atlassian.net/browse/UID-723)

[UID-723]: https://bonitasoft.atlassian.net/browse/UID-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

can be back-ported on bonita-ui-designer-internal for 7.14.x, 7.15.x and 8.0.x eventually 