### PR TITLE
fix(JSMin): Support multiline string template

### DIFF
--- a/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/export/Minifier.java
+++ b/generator-angularjs/src/main/java/org/bonitasoft/web/angularjs/export/Minifier.java
@@ -16,29 +16,23 @@
  */
 package org.bonitasoft.web.angularjs.export;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
-import org.bonitasoft.web.designer.common.generator.rendering.GenerationException;
+import java.nio.charset.StandardCharsets;
 
 import inconspicuous.jsmin.JSMin;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public final class Minifier {
 
     public static byte[] minify(byte[] contentToMinify) {
-        try (var bis = new ByteArrayInputStream(contentToMinify); var out = new ByteArrayOutputStream()) {
-            var jsmin = new JSMin(bis, out);
-            jsmin.jsmin();
-            return out.toByteArray();
-        } catch (IOException e) {
-            throw new GenerationException("Error when minify", e);
-        } catch (JSMin.UnterminatedCommentException e) {
-            throw new GenerationException("Error when minify: Unterminated Comment", e);
-        } catch (JSMin.UnterminatedStringLiteralException e) {
-            throw new GenerationException("Error when minify: Unterminated String", e);
-        } catch (JSMin.UnterminatedRegExpLiteralException e) {
-            throw new GenerationException("Error when minify: Unterminated RegExp literal", e);
+        String jsmin;
+        try {
+            jsmin = JSMin.minify(new String(contentToMinify, StandardCharsets.UTF_8));
+            return jsmin.getBytes(StandardCharsets.UTF_8);
+        } catch (JSMin.MinifyException e) {
+            log.warn("Something went wrong when minifying JS content. Non minified content will be packaged instead.",
+                    e);
+            return contentToMinify;
         }
     }
 }

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/export/MinifierTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/export/MinifierTest.java
@@ -17,12 +17,10 @@
 package org.bonitasoft.web.angularjs.export;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.bonitasoft.web.designer.common.generator.rendering.GenerationException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,12 +33,13 @@ class MinifierTest {
         String content = "function PbInputCtrl($scope, $log, widgetNameFactory) {\n" + "\n'use strict';\n" +
                 "\n  this.name = widgetNameFactory.getName('pbInput');\n" +
                 "\n  var myString = `http://some-url.com ${name} other`;\n" +
+                "\n  var myMultiLineString = `Hello \n other`;\n" +
                 "\n  if (!$scope.properties.isBound('value')) {\n" +
                 "    $log.error('the pbInput property named \"value\" need to be bound to a variable');\n" +
                 "  }\n}\n";
         String expected = "\n" +
                 "function PbInputCtrl($scope,$log,widgetNameFactory){'use strict';this.name=widgetNameFactory.getName" +
-                "('pbInput');var myString=`http://some-url.com ${name} other`;if(!$scope.properties.isBound('value')){$log.error('the pbInput property named \"value\""
+                "('pbInput');var myString=`http://some-url.com ${name} other`;var myMultiLineString=`Hello \n other`;if(!$scope.properties.isBound('value')){$log.error('the pbInput property named \"value\""
                 +
                 " need to be bound to a variable');}}";
 
@@ -54,7 +53,7 @@ class MinifierTest {
         String badCommentTemplate = "/** dffsf /";
         var content = (badCommentTemplate + "content").getBytes();
 
-        assertThrows(GenerationException.class, () -> Minifier.minify(content));
+        assertThat(Minifier.minify(content)).isEqualTo(content);
     }
 
     @Test
@@ -62,6 +61,6 @@ class MinifierTest {
         String unterminatedString = "'use strict\n";
         var content = ("function PbInputCtrl($scope, $log, widgetNameFactory) { \n" + unterminatedString).getBytes();
 
-        assertThrows(GenerationException.class, () -> Minifier.minify(content));
+        assertThat(Minifier.minify(content)).isEqualTo(content);
     }
 }


### PR DESCRIPTION
The current version does not support it and fails the export.

This new version supports it and now failing the minification will not fail the export:
* Use the non-minified content
* Log a warning instead of failing the export