### PR TITLE
chore(build): Allow to keep node_modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,5 +457,31 @@
         <spotless.check.skip>true</spotless.check.skip>
       </properties>
     </profile>
+    <profile>
+      <id>keepNodeModules</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>node</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+                <fileset>
+                  <directory>infrastructure/crowdin/build</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
node_modules is usefull if you want to go offline.
Make it optional in the maven clean so Code Deposit can keep it.