### PR TITLE
fix(local): Update first day of the week for JP and BR

### DIFF
--- a/generator-angularjs/src/main/resources/templates/page/assets/json/localization.json
+++ b/generator-angularjs/src/main/resources/templates/page/assets/json/localization.json
@@ -359,7 +359,7 @@
           "\u91d1\u66dc\u65e5",
           "\u571f\u66dc\u65e5"
         ],
-        "FIRSTDAYOFWEEK": 6,
+        "FIRSTDAYOFWEEK": 0,
         "MONTH": [
           "1\u6708",
           "2\u6708",
@@ -496,7 +496,7 @@
           "sexta-feira",
           "s\u00e1bado"
         ],
-        "FIRSTDAYOFWEEK": 6,
+        "FIRSTDAYOFWEEK": 0,
         "MONTH": [
           "janeiro",
           "fevereiro",


### PR DESCRIPTION
**Description:**  
This PR adjusts the first day of the week in the localization configurations for the Japanese (JP) and Brazilian Portuguese (BR) locales. Ensuring these settings align with regional norms improves the overall user experience and consistency of date displays.

**Changes:**  
- Updated the JP localization file to set Sunday as the first day of the week.  
- Updated the BR localization file to set Sunday as the first day of the week.

Cover https://bonitasoft.atlassian.net/browse/UID-737