### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ To release a new version, maintainers may use the Release and Publication GitHub
 
 [java]: https://adoptium.net/temurin/releases/?version=11
 [uid-repo]: https://github.com/bonitasoft/bonita-ui-designer
-[documentation]: https://documentation.bonitasoft.com
+[documentation]: https://documentation.ofelia.com
 
     

--- a/artifact-builder/src/test/java/org/bonitasoft/web/designer/migration/AssetExternalMigrationStepTest.java
+++ b/artifact-builder/src/test/java/org/bonitasoft/web/designer/migration/AssetExternalMigrationStepTest.java
@@ -34,7 +34,7 @@ class AssetExternalMigrationStepTest {
                 .withAsset(anAsset()
                         .withName("bonita.jpg"))
                 .withAsset(anAsset()
-                        .withName("http://www.bonitasoft.com"))
+                        .withName("http://www.ofelia.com"))
                 .build();
 
         migrationStep.migrate(page);
@@ -43,7 +43,7 @@ class AssetExternalMigrationStepTest {
                 .extracting("name", "external")
                 .containsOnly(
                         tuple("bonita.jpg", false),
-                        tuple("http://www.bonitasoft.com", true));
+                        tuple("http://www.ofelia.com", true));
     }
 
     @Test
@@ -54,7 +54,7 @@ class AssetExternalMigrationStepTest {
                 .withAsset(anAsset()
                         .withExternal(false).withName("bonita.jpg"))
                 .withAsset(anAsset()
-                        .withExternal(true).withName("https://www.bonitasoft.com"))
+                        .withExternal(true).withName("https://www.ofelia.com"))
                 .build();
 
         migrationStep.migrate(page);
@@ -63,6 +63,6 @@ class AssetExternalMigrationStepTest {
                 .extracting("name", "external")
                 .containsOnly(
                         tuple("bonita.jpg", false),
-                        tuple("https://www.bonitasoft.com", true));
+                        tuple("https://www.ofelia.com", true));
     }
 }


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft → Ofelia rebranding.