### PR TITLE
ci(claude): set up Claude Code (CLAUDE.md + GitHub workflows)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,113 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [ opened, labeled ]
+    paths-ignore:
+      # Ignore Claude Code review on Crowdin translation files changes
+      - 'generator-angularjs/src/main/resources/i18n/*.po'
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  claude-review:
+    # Only run when:
+    # 1. PR is created
+    # 2. Comment on PR contains "@claude review"
+    # 3. Label "ask-claude-review" is added to PR
+    if: |
+      (
+        (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review')) ||
+        (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'ask-claude-review')
+      ) && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Get PR number
+        id: pr-number
+        run: |
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            ## FORMATTING RULE — MANDATORY (read before drafting)
+
+            GitHub auto-links bare `#N` to PRs/issues and bare `@name` to user mentions.
+            Your review references review-point numbers and code symbols, NOT real PRs/users —
+            so they MUST be wrapped in backticks to render as inline code instead of links.
+
+            WRONG: "Applied #2, #4, and #5. Use @ToString on the entity."
+            RIGHT: "Applied `#2`, `#4`, and `#5`. Use `@ToString` on the entity."
+
+            Exceptions — keep plain (no backticks):
+            - Real PR/issue references: "Fixes #1234" → leave as link.
+            - Real user mentions: "cc @akantcheff" → leave as mention.
+
+            FINAL SCAN before posting: re-read your draft, find every bare "#<digits>"
+            and every "@<word>" that is not intentionally a real user mention, and
+            wrap them in backticks. Do this even on text you generated earlier in
+            the draft — the auto-linker doesn't care which paragraph it's in.
+
+            ## POSTING THE REVIEW
+
+            Update an existing Claude review comment if present, otherwise create one.
+
+            Step 1 — Find existing Claude review comment (REQUIRED):
+            COMMENT_ID=$(gh pr view ${{ steps.pr-number.outputs.pr_number }} --json comments --jq '.comments[] | select(.body | contains("## Claude Code Review")) | .id' | head -1)
+
+            Step 2 — Build the markdown body:
+            - Start with "## Claude Code Review" header (REQUIRED for identification).
+            - Add timestamp: "**Last updated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            - Include review counter if updating: "**Review iteration:** `#N`"  (note backticks — see formatting rule)
+            - Then provide your detailed review.
+
+            Step 3 — ALWAYS update existing comment if it exists (MANDATORY):
+            if [ -n "$COMMENT_ID" ]; then
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --edit-last --body "<your-review-markdown>"
+              echo "✓ Updated existing review comment ID: $COMMENT_ID"
+            else
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --body "<your-review-markdown>"
+              echo "✓ Created initial review comment"
+            fi
+
+            ## REMINDERS
+
+            1. NEVER create a new "## Claude Code Review" comment if one exists — always edit the existing one.
+            2. Always start with "## Claude Code Review" for identification.
+            3. Include timestamp to show when the review was last updated.
+            4. Final formatting check: re-scan the draft for bare "#<digits>" or non-mention "@<word>" and wrap them in backticks before posting.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A library (published to Maven Central as `org.bonitasoft.web:ui-designer-artifact-builder`) that builds artifacts designed with the Bonita UI Designer: it imports/migrates page, fragment and widget JSON models and generates the runnable HTML/zip output. Java 11, multi-module Maven, gitflow branching (default branch: `develop`, PRs target `develop`).
+
+## Build & test commands
+
+```bash
+./mvnw clean verify                 # full build + unit tests + the IT
+./mvnw spotless:apply               # fix formatting (build FAILS on violations otherwise)
+./mvnw test -pl artifact-builder    # tests for one module
+./mvnw test -pl artifact-builder -Dtest=DefaultArtifactBuilderTest                 # single class
+./mvnw test -pl artifact-builder -Dtest='DefaultArtifactBuilderTest#should_*'      # single method(s)
+./mvnw verify -pl artifact-builder -Dit.test=ArtifactBuilderIT                     # the integration test
+```
+
+Gotchas:
+- **PhantomJS** (JS tests in `generator-angularjs`): on Ubuntu 24 set `OPENSSL_CONF=/dev/null` or the build fails at phantomjs startup.
+- **Spotless runs at `process-sources` and fails the build**: Eclipse formatter (`formatter.xml`), import order `java/javax/org/com` (`eclipse.importorder`), license header (`header.txt`), sorted poms. `-Poffline` skips the check.
+- `-PkeepNodeModules` avoids wiping `node_modules` on `clean` (yarn install is slow).
+- Building a module alone requires its siblings installed or `-am` (e.g. `./mvnw test -pl common -am`).
+
+## Module dependency graph
+
+```
+model ──> common ──> generator-angularjs ──┐
+  │         │                              ├──> artifact-builder ──> coverage-report
+  └─────────┴──────────── migrationReport ─┘
+artifact-builder-dependencies (BOM only, no code)
+```
+
+- **model** — POJOs (`Page`, `Fragment`, `Widget`, `Element` hierarchy), `JsonHandler`/`JacksonJsonHandler`, and the `ElementVisitor<T>` interface everything else implements. No Spring.
+- **common** — file-based repositories (`PageRepository`, `WidgetRepository`, `JsonFileBasedLoader/Persister`), live build (`Watcher`), export infrastructure (`ExportStep`, `Zipper`), `migration.Version`, `GeneratorStrategy` abstraction.
+- **generator-angularjs** — the AngularJS rendering backend: `AngularJsGeneratorStrategy`, `HtmlBuilderVisitor`, Handlebars templates (`src/main/resources/templates/*.hbs.*`), 27 provided `pb*` widgets, plus a gulp-built JS runtime (see below).
+- **artifact-builder** — public API and wiring: services, importers/exporters, migration step definitions.
+- **migrationReport** — 4 DTO classes (`MigrationReport`, `MigrationStepReport`…) kept as a separate module so consumers can depend on the report types alone.
+- **coverage-report** — JaCoCo aggregation for Sonar; not published.
+
+## Architecture
+
+**Entry point**: `ArtifactBuilder` interface → `DefaultArtifactBuilder`, created via `new ArtifactBuilderFactory(UiDesignerProperties).create()`. All wiring is done by hand in `ArtifactBuilderFactory` and `UiDesignerCoreFactory` (no Spring context — spring-core is only used for classpath resource scanning). Configuration via `UiDesignerPropertiesBuilder`; use `.disableLiveBuild()` for library/CI use, otherwise a file watcher thread starts.
+
+**Build flow (page → zip)**: `DefaultArtifactBuilder.build()` → `PageExporter` → `DefaultPageService.get(id)` (loads JSON, applies migrations) → ordered `ExportStep`s write into a `Zipper` (`PagePropertiesExportStep`, `AssetExportStep`, `FragmentsExportStep`, `HtmlExportStep`, `WidgetsExportStep`).
+
+**Rendering (model → HTML)**: `HtmlBuilderVisitor implements ElementVisitor<String>` walks the element tree; each `visit()` renders a Handlebars template via `TemplateEngine`. The visitor pattern is the core idiom — cross-cutting concerns are separate visitors (`WidgetIdVisitor`, `AssetVisitor`, `PropertyValuesVisitor`, …).
+
+**Migrations**: a `Migration<A>(targetVersion, MigrationStep<A>...)` applies steps when the artifact's version is older. Steps live in `artifact-builder`'s `org.bonitasoft.web.designer.migration` (+ `.page`). **The ordered migration lists are hardcoded in `UiDesignerCoreFactory.create()`**, keyed by version strings up to the current model version — adding a model version means adding entries there and bumping `<uidModelVersion>` in the root pom. Whole-workspace migration happens at `Workspace.initialize()` via `LiveRepositoryUpdate`.
+
+**JSON**: `JacksonJsonHandler` built by `JsonHandlerFactory`. `DEFAULT_VIEW_INCLUSION` is disabled, so **Jackson views are mandatory** — a field without `@JsonView(JsonViewPersistence.class)` is silently not persisted. `Element` polymorphism uses `@JsonTypeInfo(property = "type")` with subtypes registered explicitly in `JsonHandlerFactory` — new element types must be registered there.
+
+**Runtime resources travel via the classpath**: generator-angularjs jars its gulp-built JS runtime under `META-INF/resources/runtime/**` and widgets under `widgets/**`; `Workspace.initialize()` extracts them into `<workspaceUid>/extract/angularjs` (deleted and re-created each time) and copies `pb*` widgets into the user widget repository.
+
+## Non-obvious build mechanics
+
+- **Generated sources**: `artifact-builder` and `generator-angularjs` filter `src/main/java-templates/**` (e.g. `Version.java` with `${project.version}`) into `target/generated-sources` — the IDE won't compile until Maven has run once. `generator-angularjs` also runs jsonschema2pojo on `target/widget-schema/`.
+- **generator-angularjs needs node**: frontend-maven-plugin installs node/yarn at the repo root and runs gulp (`yarn run build` outputs directly into `target/classes`; `yarn test` runs karma/jasmine). A GitHub dependency (`bonitasoft/widget-builder`) supplies a Handlebars template copied out of `node_modules`.
+- Lombok is used throughout (`provided` scope) — IDE needs annotation processing enabled.
+
+## Conventions
+
+- **Commit messages** follow `type(category): description` (types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `breaking`, …) — the changelog is generated from them.
+- **Tests**: JUnit 5 + AssertJ + Mockito. Surefire runs `*Test`; failsafe runs `*IT` (currently only `ArtifactBuilderIT`, a full import→build→unzip round trip). Use the fluent test-data builders in `model`'s `org.bonitasoft.web.designer.builder` (`PageBuilder`, `WidgetBuilder`, `aPage()`, …) — they're shared between modules via test-jars. Any update must be tested, at least with unit tests.
+- JS tests for the AngularJS runtime live in `generator-angularjs/src/test/javascript` (karma).


### PR DESCRIPTION
## What

Set up Claude Code for this repository:

- **`CLAUDE.md`** — guidance for Claude Code sessions: build/test commands, module dependency graph, architecture overview (entry points, page→zip flow, visitor-based rendering, migration system, Jackson views), non-obvious build mechanics and conventions.
- **`.github/workflows/claude.yml`** — interactive Claude Code workflow, triggered by `@claude` mentions in issues, PR comments and reviews.
- **`.github/workflows/claude-code-review.yml`** — automated PR review, triggered on PR open, by an `@claude review` comment, or by adding the `ask-claude-review` label.

## Notes

- Both workflows are aligned with [bonitasoft/bonita-engine-sp](https://github.com/bonitasoft/bonita-engine-sp/tree/dev/.github/workflows) (same pinned action SHAs, same `ORGANIZATION_ANTHROPIC_API_KEY` org secret).
- Only adaptation: the review workflow's `paths-ignore` for Crowdin translation files points to this repo's location (`generator-angularjs/src/main/resources/i18n/*.po`).
- The `ask-claude-review` label must exist in this repo for the label trigger to be usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
