### PR TITLE
test(junit5): revive silently skipped JUnit 4 tests in generator-angularjs

### DIFF
--- a/generator-angularjs/pom.xml
+++ b/generator-angularjs/pom.xml
@@ -70,11 +70,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/generator-angularjs/pom.xml
+++ b/generator-angularjs/pom.xml
@@ -65,11 +65,6 @@
     </dependency>
     <!--    Test Dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/DefaultHtmlGeneratorTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/DefaultHtmlGeneratorTest.java
@@ -52,7 +52,6 @@ import org.bonitasoft.web.designer.model.page.Page;
 import org.bonitasoft.web.designer.model.widget.Widget;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,8 +63,7 @@ class DefaultHtmlGeneratorTest {
 
     private static final byte[] assetsContent = new byte[0];
 
-    @Rule
-    public TestResource testResource = new TestResource(DefaultHtmlGenerator.class);
+    private final TestResource testResource = new TestResource(DefaultHtmlGenerator.class);
 
     @Mock
     private PageFactory pageFactory;

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/TemplateEngineTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/rendering/TemplateEngineTest.java
@@ -20,11 +20,8 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.bonitasoft.web.designer.common.generator.rendering.GenerationException;
-import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
 
-@ExtendWith(MockitoExtension.class)
 class TemplateEngineTest {
 
     @Test

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/utils/rule/TestResource.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/utils/rule/TestResource.java
@@ -21,12 +21,10 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.rules.ExternalResource;
 
-public class TestResource extends ExternalResource {
+public class TestResource {
 
-    String packageName;
-    InputStream stream;
+    private final String packageName;
 
     public TestResource(Class<?> aClass) {
         this.packageName = aClass.getPackage().getName();
@@ -34,8 +32,7 @@ public class TestResource extends ExternalResource {
 
     public String load(String fileName) {
         String filePath = "/" + packageName.replace(".", "/") + "/" + fileName;
-        try {
-            stream = getClass().getResourceAsStream(filePath);
+        try (InputStream stream = getClass().getResourceAsStream(filePath)) {
             if (stream == null) {
                 throw new Error(String.format("Unable to load test resource %s", filePath));
             }
@@ -44,17 +41,4 @@ public class TestResource extends ExternalResource {
             throw new Error(String.format("Unable to load test resource %s", filePath), e);
         }
     }
-
-    @Override
-    protected void before() throws Throwable {
-        super.before();
-        stream = getClass().getResourceAsStream(packageName);
-    }
-
-    @Override
-    protected void after() {
-        IOUtils.closeQuietly(stream);
-        super.after();
-    }
-
 }

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/visitor/HtmlBuilderVisitorTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/visitor/HtmlBuilderVisitorTest.java
@@ -59,7 +59,7 @@ class HtmlBuilderVisitorTest {
     @Mock
     private FragmentRepository fragmentRepository;
 
-    public TestResource testResource = new TestResource(DefaultHtmlGenerator.class);
+    private final TestResource testResource = new TestResource(DefaultHtmlGenerator.class);
 
     @BeforeEach
     void setUp() throws Exception {
@@ -196,7 +196,7 @@ class HtmlBuilderVisitorTest {
     }
 
     @Test
-    public void should_build_a_tab_container_without_lazy_load_property() throws Exception {
+    void should_build_a_tab_container_without_lazy_load_property() throws Exception {
         assertThatHtmlBody(visitor.visit(aTabContainer()
                 .withId("1")
                 .with(aContainer()
@@ -207,7 +207,7 @@ class HtmlBuilderVisitorTest {
     }
 
     @Test
-    public void should_generate_html_for_a_formcontainer() throws GenerationException {
+    void should_generate_html_for_a_formcontainer() throws GenerationException {
         assertThatHtmlBody(
                 visitor.visit(aFormContainer()
                         .with(aContainer().withReference("container-reference").build())

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/visitor/HtmlBuilderVisitorTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/visitor/HtmlBuilderVisitorTest.java
@@ -94,7 +94,7 @@ class HtmlBuilderVisitorTest {
                 .build())).isEqualToBody(testResource.load("simplecontainer.html"));
     }
 
-    @org.junit.Test
+    @Test
     void should_add_rows_to_the_container() {
 
         assertThatHtmlBody(visitor.visit(aContainer().with(aRow()).withReference("container-reference").build()))
@@ -183,8 +183,8 @@ class HtmlBuilderVisitorTest {
                 .build())).isEqualToBody(testResource.load("tabsContainerWithContent.html"));
     }
 
-    @org.junit.Test
-    public void should_build_a_tab_container_with_lazy_load_property() throws Exception {
+    @Test
+    void should_build_a_tab_container_with_lazy_load_property() throws Exception {
         assertThatHtmlBody(visitor.visit(aTabContainer()
                 .withId("1")
                 .with(aContainer()

--- a/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/visitor/PropertyValuesVisitorTest.java
+++ b/generator-angularjs/src/test/java/org/bonitasoft/web/angularjs/visitor/PropertyValuesVisitorTest.java
@@ -41,7 +41,6 @@ import org.bonitasoft.web.designer.common.repository.exception.RepositoryExcepti
 import org.bonitasoft.web.designer.model.page.Component;
 import org.bonitasoft.web.designer.model.page.Page;
 import org.bonitasoft.web.designer.model.page.PropertyValue;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,8 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PropertyValuesVisitorTest {
 
-    @Rule
-    public TestResource testResource = new TestResource(this.getClass());
+    private final TestResource testResource = new TestResource(this.getClass());
 
     @Mock
     private FragmentRepository fragmentRepository;


### PR DESCRIPTION
## What

Addresses point `#4` of the #288 code review: JUnit 4 tests silently skipped in `generator-angularjs`.

Surefire only runs Jupiter tests (there is no vintage engine in the build), so anything annotated with JUnit 4's `@Test` was silently ignored — no failure, no skip marker, not even a surefire report file.

## Changes

- **`TemplateEngineTest`**: its 6 tests had JUnit 4 `org.junit.Test` imports and were never executed. Converted to Jupiter; also dropped the unused `MockitoExtension` (the class has no mocks).
- **`HtmlBuilderVisitorTest`**: beyond what the review spotted, 2 methods used fully-qualified `@org.junit.Test` and were skipped the same way. Converted — the class now runs 22 tests instead of 20.
- **`TestResource`**: no longer extends JUnit 4's `ExternalResource` rule (its `before`/`after` callbacks never ran under Jupiter anyway); `load()` now closes its stream with try-with-resources.
- **`DefaultHtmlGeneratorTest` / `PropertyValuesVisitorTest`**: removed the inert `@Rule` annotations.
- **`generator-angularjs/pom.xml`**: removed the `junit:junit` dependency — nothing JUnit 4 remains in the repo.

## Verification

- All 8 revived tests pass: module suite goes from 90 to **98 tests, 0 failures**.
- Full `./mvnw clean verify` green on all 8 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
