### PR TITLE
ci(release): let PhantomJS start during the gitflow test build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Create Release
+        env:
+          OPENSSL_CONF: /dev/null # Disable OpenSSL config to let phantomjs start, see https://stackoverflow.com/a/72679175
         run: >
           ./mvnw -ntp --batch-mode gitflow:release
           -DgitFlowConfig.developmentBranch=${{ github.ref_name }}


### PR DESCRIPTION
## What

One-line fix unblocking the 2.0.0 release: the `Create Release` step now sets `OPENSSL_CONF: /dev/null`, like `build.yml`, `build-pr.yml` and `publish.yml` already do on their Maven steps.

## Why

`gitflow:release` runs `./mvnw clean test` internally. On the ubuntu-24.04 runner, the `generator-angularjs` karma suite fails at PhantomJS startup (`Auto configuration failed` - the OpenSSL 3 config issue) unless `OPENSSL_CONF=/dev/null` is set. `release.yml` was the only workflow missing the variable, which is why [Release 2.0.0](https://github.com/bonitasoft/bonita-ui-designer-artifact-builder/actions/runs/31091786461) failed at that exact point once the missing-`master`-branch issue was resolved (`master` now exists at the 1.0.10 tag).

## Release path after merge

Re-dispatch Release with version `2.0.0` and `skipMergeReleaseInMaster` unchecked (major release, merges into the new `master`).